### PR TITLE
chore: add macOS Darwin config to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -21,7 +21,12 @@ in
 mkShell {
   buildInputs = [ erlang elixir ]
     ++ optional stdenv.isLinux inotify-tools
-  ;
+    ++ optionals stdenv.isDarwin (with darwin.apple_sdk.frameworks; [
+      # For file_system on macOS.
+      CoreFoundation
+      CoreServices
+    ]);
+
   shellHook = ''
     export LOCALE_ARCHIVE=/usr/lib/locale/locale-archive
   '';


### PR DESCRIPTION
Running `nix-shell` already seemed to work fine before adding this, but I believe it is the recommended config for macOS darwin.